### PR TITLE
Feature - API changes (related to BE#36)

### DIFF
--- a/src/apis/rembrandt/lib/ResourceInstance.ts
+++ b/src/apis/rembrandt/lib/ResourceInstance.ts
@@ -23,7 +23,7 @@ const serializer = new Serializer('resourceInstance', {
 });
 
 export const ResourceInstances = new CRUDResource<ResourceInstance>(
-  `${config.backendHost}/resource-instances`,
+  `${config.backendHost}/organization/resource-instances`,
   serializer,
 );
 

--- a/src/apis/rembrandt/lib/ResourceType.ts
+++ b/src/apis/rembrandt/lib/ResourceType.ts
@@ -30,7 +30,7 @@ const serializer = new Serializer('resourceType', {
 });
 
 export const ResourceTypes = new CRUDResource<ResourceType>(
-  `${config.backendHost}/resource-types`,
+  `${config.backendHost}/organization/resource-types`,
   serializer,
 );
 


### PR DESCRIPTION
This PR addresses the API changes mentioned in bptlab/rembrandt-backend#36.

The API now calls `/organization/resource-types` and `/organization/resource-instances`.

(See also related issue bptlab/rembrandt-backend#34)