### PR TITLE
Add link to view execution result instances

### DIFF
--- a/src/views/Execution.vue
+++ b/src/views/Execution.vue
@@ -2,7 +2,11 @@
   <main>
     <ViewHeader :title="execution.identifier" :backLink="{ link: { name: 'executions' } }"/>
     <ListSection class="preview-container" :list="executionList"/>
-    <ListSection title="Ingredient States" :list="executionStatesList"/>
+
+    <div class="row">
+      <ListSection title="Ingredient States" :list="executionStatesList"/>
+      <ListSection title="Actions" :list="executionActionsList" />
+    </div>
   </main>
 </template>
 
@@ -17,6 +21,7 @@ import ViewHeader from '@/components/ViewHeader.vue';
 import ListSection from '@/components/ListSection.vue';
 import { ListEntry } from '@/components/Li.vue';
 import Utils from '@/utils/Utils';
+import { NotificationLevel } from '@/interfaces/Notification';
 
 @Component({
   components: {
@@ -38,9 +43,36 @@ export default class Algorithm extends Vue {
     return Utils.optimizationExecutionsToList([ this.execution ]);
   }
 
-
   public get executionStatesList(): ListEntry[] {
     return Utils.optimizationExecutionStatesToList(this.execution);
+  }
+
+  public get executionActionsList(): ListEntry[] {
+    const executionActionList = [];
+
+    if (this.execution.successful) {
+      executionActionList.push(
+        {
+          id: '1',
+          firstValue: 'View Result',
+          link: {
+            link: { name: 'resources', query: { execution: this.execution.id } },
+          },
+        },
+      );
+    }
+
+    executionActionList.push(
+      {
+        id: '2',
+        firstValue: 'Delete Execution',
+        link: {
+          onClick: this.deleteExecution,
+        },
+      },
+    );
+
+    return executionActionList;
   }
   // endregion
 
@@ -58,6 +90,21 @@ export default class Algorithm extends Vue {
   public async mounted() {
     try {
       this.execution = await OptimizationExecutions.getOne(this.$route.params.id);
+    } catch (e) {
+      this.$notifications.create(e);
+    }
+  }
+
+  public async deleteExecution(): Promise<void> {
+    try {
+      await OptimizationExecutions.delete(this.execution.id!);
+      this.$notifications.create({
+        title: `Execution '${this.execution.identifier}' has been deleted.`,
+        details: '',
+        level: NotificationLevel.Success,
+        timestamp: new Date(),
+      });
+      this.$router.push({ name: 'executions' });
     } catch (e) {
       this.$notifications.create(e);
     }


### PR DESCRIPTION
In the execution detail view, there is now a button to view the result of this execution (if it was successful).
The button redirects to the resources view and limits the shown instances to the ones created in the execution.
(The execution id is passed as a url query param)